### PR TITLE
Change CursorLineNr color

### DIFF
--- a/colors/challenger_deep.vim
+++ b/colors/challenger_deep.vim
@@ -146,8 +146,8 @@ hi! link Debug            Special
 
 call s:h("Underlined",    {"fg": s:norm                      , "gui": "underline", "cterm": "underline"})
 call s:h("Ignore",        {"fg": s:bg                                                                  })
-call s:h("Error",         {"fg": s:actual_white, "bg": s:dark_red , "gui": "bold"     , "cterm": "bold"     })
-call s:h("Todo",          {"fg": s:actual_white, "bg": s:blue, "gui": "bold"     , "cterm": "bold"     })
+call s:h("Error",         {"fg": s:dark_red, "bg": s:bg_subtle , "gui": "bold"     , "cterm": "bold"     })
+call s:h("Todo",          {"fg": s:dark_yellow, "bg": s:bg_subtle, "gui": "bold"     , "cterm": "bold"     })
 
 " ui chrome ====================================================================
 " ordered according to `:help hitest.vim`
@@ -310,10 +310,10 @@ hi! link xmlTagName                 htmlTagName
 hi link SignifySignAdd              LineNr
 hi link SignifySignDelete           LineNr
 hi link SignifySignChange           LineNr
-call s:h("GitGutterAdd",{"fg": s:green})
-call s:h("GitGutterDelete",{"fg": s:red})
-call s:h("GitGutterChange",{"fg": s:yellow})
-call s:h("GitGutterChangeDelete",{"fg": s:red})
+call s:h("GitGutterAdd",{"fg": s:green, "bg": s:bg_subtle})
+call s:h("GitGutterDelete",{"fg": s:red, "bg": s:bg_subtle})
+call s:h("GitGutterChange",{"fg": s:yellow, "bg": s:bg_subtle})
+call s:h("GitGutterChangeDelete",{"fg": s:red, "bg": s:bg_subtle})
 
 
 "nvim terminal colors

--- a/colors/challenger_deep.vim
+++ b/colors/challenger_deep.vim
@@ -164,7 +164,7 @@ call s:h("Search",        {"bg": s:bg_dark})
 call s:h("MoreMsg",       {"fg": s:medium_gray, "gui": "bold", "cterm": "bold"})
 hi! link ModeMsg MoreMsg
 call s:h("LineNr",        {"fg": s:dark_asphalt, "bg": s:bg_subtle})
-call s:h("CursorLineNr",  {"bg": s:blue, "fg": s:bg_subtle})
+call s:h("CursorLineNr",  {"bg": s:bg, "fg": s:blue})
 call s:h("Question",      {"fg": s:red})
 call s:h("StatusLine",    {"bg": s:bg_dark})
 call s:h("Conceal",       {"fg": s:norm})

--- a/colors/challenger_deep.vim
+++ b/colors/challenger_deep.vim
@@ -164,7 +164,7 @@ call s:h("Search",        {"bg": s:bg_dark})
 call s:h("MoreMsg",       {"fg": s:medium_gray, "gui": "bold", "cterm": "bold"})
 hi! link ModeMsg MoreMsg
 call s:h("LineNr",        {"fg": s:dark_asphalt, "bg": s:bg_subtle})
-call s:h("CursorLineNr",  {"bg": s:bg, "fg": s:blue})
+call s:h("CursorLineNr",  {"bg": s:bg, "fg": s:blue, "gui": "bold"})
 call s:h("Question",      {"fg": s:red})
 call s:h("StatusLine",    {"bg": s:bg_dark})
 call s:h("Conceal",       {"fg": s:norm})

--- a/colors/challenger_deep.vim
+++ b/colors/challenger_deep.vim
@@ -164,7 +164,7 @@ call s:h("Search",        {"bg": s:bg_dark})
 call s:h("MoreMsg",       {"fg": s:medium_gray, "gui": "bold", "cterm": "bold"})
 hi! link ModeMsg MoreMsg
 call s:h("LineNr",        {"fg": s:dark_asphalt, "bg": s:bg_subtle})
-call s:h("CursorLineNr",  {"bg": s:bg, "fg": s:blue, "gui": "bold"})
+call s:h("CursorLineNr",  {"bg": s:bg_subtle, "fg": s:blue, "gui": "bold"})
 call s:h("Question",      {"fg": s:red})
 call s:h("StatusLine",    {"bg": s:bg_dark})
 call s:h("Conceal",       {"fg": s:norm})


### PR DESCRIPTION
Having the background of `CursorLineNr` blue is really hard to see the cursor in insert mode if the cursor is in column 1:

<img width="684" alt="screen shot 2018-05-22 at 8 30 08 pm" src="https://user-images.githubusercontent.com/17645203/40365557-fd9e2692-5dfe-11e8-95f3-693dde4f5782.png">

So I suggest to change the background of `CursorLineNr` to background color, set the color of the number to blue and make it bold instead:

<img width="691" alt="screen shot 2018-05-22 at 8 33 51 pm" src="https://user-images.githubusercontent.com/17645203/40365846-c3f941f0-5dff-11e8-9753-655b8736c1d7.png">

I'm not sure if this is against the design of the theme, but it looks more natural in my eyes.

## Update

Gitgutter:

<img width="99" alt="screen shot 2018-05-23 at 10 17 56 pm" src="https://user-images.githubusercontent.com/17645203/40433894-5bfc2a94-5ed7-11e8-8086-9b2e4b0ac874.png">

Error:

<img width="291" alt="screen shot 2018-05-23 at 10 10 24 pm" src="https://user-images.githubusercontent.com/17645203/40433907-6297c50c-5ed7-11e8-9736-d5dd4f950c42.png">

Todo:

<img width="112" alt="screen shot 2018-05-23 at 10 14 02 pm" src="https://user-images.githubusercontent.com/17645203/40433914-6785ee5e-5ed7-11e8-9391-aeb7c037d199.png">